### PR TITLE
Add option to skip css file creation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,11 +25,13 @@ function generateFiles({ type, name, path, indexFile, cssExtension, jsExtension,
   if (indexFile || connected) {
     fs.outputFile(`${destination}/index.js`, generateIndexFile(name, connected))
   }
-    // Create js file
+  // Create js file
   fs.outputFile(`${destination}/${name}.${jsExtension}`, generateComponentTemplate(type, name))
 
+  if (cssExtension !== 'skip') {
     // Create css file
-  fs.outputFile(`${destination}/${name}.${cssExtension}`, generateStyleFile(name))
+    fs.outputFile(`${destination}/${name}.${cssExtension}`, generateStyleFile(name))
+  }
 }
 
 /**

--- a/src/questions.js
+++ b/src/questions.js
@@ -33,7 +33,7 @@ const questions = {
     type: 'list',
     name: 'cssExtension',
     message: 'What kind of extension do you use for css files ?',
-    choices: ['css', 'scss', 'sass', 'less'],
+    choices: ['css', 'scss', 'sass', 'less', 'skip'],
   },
   path: {
     type: 'input',


### PR DESCRIPTION
Hey, cool app!

This PR adds option `skip` to `cssExtension` question, as sometimes stylesheet files aren't needed (for example for CSS-in-JS.

Feel free to add improvements or suggestions!

Signed-off-by: Pete Nykanen <pete.a.nykanen@gmail.com>