### PR TITLE
Added the ability to define a config folder in a project directory & fixed truthy bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,26 @@ $ npm install -g create-component-app
 ```sh
 $ cd ~/my-projects
 $ create-component-app
+```    
+
+### You can create a configuration file in your current project directory    
+
+Create a file in your project folder named `.ccarc`:    
+
+```javascript
+{   
+    "type": "stateless", 
+    "path": "./src/components",
+    "jsExtension": "js",
+    "cssExtension": "scss",
+    "indexFile": false,
+    "connected": false
+}
 ```
 
-### You can specify default values to save a lot of time
+### You can also pass a config file directory
 
-If you want, you can set default values from a JSON:  
+Create a JSON file `config.json`:  
 
 ```javascript
 {   
@@ -53,7 +68,9 @@ If you want, you can set default values from a JSON:
 and pass the path to config param
 ```sh
 $ create-component-app --config path/to/your/config.json
-```
+```    
+
+Passing a config file via the CLI overrides the configuration file in the working directory
 
 ## Future
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,17 @@ import { generateComponentTemplate, generateStyleFile, generateIndexFile } from 
 import questions from './questions'
 
 // Dynamically import the config file if exist
-const configPath = yargs.argv.config
-const config = configPath ? require(`${process.cwd()}/${configPath}`) : null
+let config = null
+const argsConfigPath = yargs.argv.config
+const directoryConfig = `${process.cwd()}/.ccarc`
+    
+    if (fs.existsSync(directoryConfig)) {
+        config = JSON.parse(fs.readFileSync(directoryConfig, "utf8"))
+    }
+    
+    if (argsConfigPath){
+        config = require(`${process.cwd()}/${argsConfigPath}`)
+    }
 
 /**
  * Generate component files
@@ -37,15 +46,14 @@ function generateFiles({ type, name, path, indexFile, cssExtension, jsExtension,
  */
 function generateQuestions() {
   const questionKeys = Object.keys(questions)
-
+  
   if (!config) {
     return questionKeys.map(question => questions[question])
   }
 
   const filteredQuestions = []
-
   questionKeys.forEach((question) => {
-    if (!config[question]) {
+    if (!config.hasOwnProperty(question)) {
       filteredQuestions.push(questions[question])
     }
   })


### PR DESCRIPTION
### Feature Addition
You can create a file, `.ccarc` in your working directory (normally the current project) and include a configuration:    
```javascript
{   
    "type": "stateless", 
    "path": "./src/components",
    "jsExtension": "js",
    "cssExtension": "scss",
    "indexFile": false,
    "connected": false
}
```   
When executed, the program will check for the existence of this `.ccarc` file. If provided a `--config` flag, the provided flag will override the `.ccarc` if it exists. 

### Bug Fix
Additionally fixed a bug when comparing the config object to the questions. Previously the code would do a `if (!config[question])` check, but if the config value was explicitly `false` (such as do not create a connector), the comparison would fail and the user would be asked the question. By switching this line to `id (!config.hasOwnProperty(question))` the bug is eliminated