### PR TITLE
Check for existence of tests as possible extension.

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -13,7 +13,13 @@ import {
  */
 function getExtension(fileName) {
   const splittedFilename = fileName.split('.')
-  return splittedFilename[splittedFilename.length - 1]
+  const length = splittedFilename.length
+
+  if (splittedFilename[1] === 'tests') {
+    return `${splittedFilename[length - 2]}.${splittedFilename[length - 1]}`
+  }
+
+  return splittedFilename[length - 1]
 }
 
 /**


### PR DESCRIPTION
Tests templates were being ignored with expected `.tests.js` style extension.