### PR TITLE
Building app should copy the config.json file to allow running it

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "lint": "eslint src test",
-    "build": "babel src -d dist",
+    "build": "babel src -d dist --copy-files",
     "watch": "npm-watch",
     "try": "node ./dist/index.js",
     "test": "jest",


### PR DESCRIPTION
When trying the app, you currently have to copy the `config.json` file into the dist folder.

By using `--copy-files` babel will copy non-js files into it's output