### PR TITLE
Fix template arg not being read according to documentation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,11 +21,28 @@ import { questions } from './questions'
 const args = yargs.argv
 const config = getConfig(args.config)
 
-async function startTemplateGenerator() {
+async function getTemplateArg() {
+  const templateArg = args.t || args.template
+  if (templateArg) {
+    return templateArg
+  }
+
+  const { template } = await inquirer.prompt([
+    {
+      type: 'confirm',
+      name: 'template',
+      message: 'Do you wanna choose a template',
+      default: false,
+    },
+  ])
+  return template
+}
+
+async function startTemplateGenerator(template) {
   try {
     const templatesDirPath = config ? config.templatesDirPath : null
     const templates = getTemplatesList(templatesDirPath)
-    const templatesPath = await getTemplate(templates, args.template)
+    const templatesPath = await getTemplate(templates, template)
 
     const requiredAnswers = await inquirer.prompt([
       questions.name,
@@ -53,21 +70,9 @@ async function startTemplateGenerator() {
  */
 (async function start() {
   try {
-    if (args.template) {
-      return await startTemplateGenerator()
-    }
-
-    const { template } = await inquirer.prompt([
-      {
-        type: 'confirm',
-        name: 'template',
-        message: 'Do you wanna choose a template',
-        default: false,
-      },
-    ])
-
+    const template = await getTemplateArg()
     if (template) {
-      return await startTemplateGenerator()
+      return await startTemplateGenerator(template)
     }
 
     const filteredQuestions = generateQuestions(config, questions)


### PR DESCRIPTION
according to docs a template can by used by using the -t option.
the script tries to read out a `template` argument.

So I adjusted the code to use both, either `--template=classic` or `-t classic`

also a bit of refactoring to startTemplateGenerator with a given template...