### PR TITLE
Fix template arg not being read according to documentation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ import { questions } from './questions'
 const args = yargs.argv
 const config = getConfig(args.config)
 
-async function getTemplateArg() {
+async function getTemplateOption() {
   const { templatesDirPath } = config
   const templates = getTemplatesList(templatesDirPath)
 
@@ -72,7 +72,7 @@ async function startTemplateGenerator(template) {
  */
 (async function start() {
   try {
-    const template = await getTemplateArg()
+    const template = await getTemplateOption()
     if (template) {
       return await startTemplateGenerator(template)
     }

--- a/src/index.js
+++ b/src/index.js
@@ -21,13 +21,17 @@ import { questions } from './questions'
 const args = yargs.argv
 const config = getConfig(args.config)
 
-async function getTemplateOption() {
+async function getTemplatesPath(templateName = null) {
   const { templatesDirPath } = config
   const templates = getTemplatesList(templatesDirPath)
 
+  return getTemplate(templates, templateName)
+}
+
+async function getTemplateOption() {
   const templateArg = args.t || args.template
   if (templateArg) {
-    return getTemplate(templates, templateArg)
+    return getTemplatesPath(templateArg)
   }
 
   const { template } = await inquirer.prompt([
@@ -39,12 +43,12 @@ async function getTemplateOption() {
     },
   ])
   if (template) {
-    return getTemplate(templates)
+    return getTemplatesPath()
   }
   return null
 }
 
-async function startTemplateGenerator(template) {
+async function startTemplateGenerator(templatesPath) {
   try {
     const requiredAnswers = await inquirer.prompt([
       questions.name,
@@ -54,7 +58,7 @@ async function startTemplateGenerator(template) {
     const results = {
       ...config,
       ...requiredAnswers,
-      templatesPath: template,
+      templatesPath,
     }
 
     generateFilesFromTemplate(results)

--- a/src/index.js
+++ b/src/index.js
@@ -21,11 +21,28 @@ import { questions } from './questions'
 const args = yargs.argv
 const config = getConfig(args.config)
 
-async function startTemplateGenerator() {
+async function getTemplateArg() {
+  const templateArg = args.t || args.template
+  if (templateArg) {
+    return templateArg
+  }
+
+  const { template } = await inquirer.prompt([
+    {
+      type: 'confirm',
+      name: 'template',
+      message: 'Do you wanna choose a template',
+      default: false,
+    },
+  ])
+  return template
+}
+
+async function startTemplateGenerator(template) {
   try {
     const templatesDirPath = config ? config.templatesDirPath : null
     const templates = getTemplatesList(templatesDirPath)
-    const templatesPath = await getTemplate(templates, args.template)
+    const templatesPath = await getTemplate(templates, template)
 
     const requiredAnswers = await inquirer.prompt([
       questions.name,
@@ -53,21 +70,9 @@ async function startTemplateGenerator() {
  */
 (async function start() {
   try {
-    if (args.template) {
-      return await startTemplateGenerator()
-    }
-
-    const { template } = await inquirer.prompt([
-      {
-        type: 'confirm',
-        name: 'template',
-        message: 'Do you wanna choose a template',
-        default: false,
-      },
-    ])
-
+    const template = await getTemplateArg()
     if (template) {
-      return await startTemplateGenerator()
+      return await startTemplateGenerator(template)
     }
 
     const filteredQuestions = generateQuestions(config, questions)

--- a/src/index.js
+++ b/src/index.js
@@ -22,9 +22,12 @@ const args = yargs.argv
 const config = getConfig(args.config)
 
 async function getTemplateArg() {
+  const { templatesDirPath } = config
+  const templates = getTemplatesList(templatesDirPath)
+
   const templateArg = args.t || args.template
   if (templateArg) {
-    return templateArg
+    return getTemplate(templates, templateArg)
   }
 
   const { template } = await inquirer.prompt([
@@ -35,15 +38,14 @@ async function getTemplateArg() {
       default: false,
     },
   ])
-  return template
+  if (template) {
+    return getTemplate(templates)
+  }
+  return null
 }
 
 async function startTemplateGenerator(template) {
   try {
-    const templatesDirPath = config ? config.templatesDirPath : null
-    const templates = getTemplatesList(templatesDirPath)
-    const templatesPath = await getTemplate(templates, template)
-
     const requiredAnswers = await inquirer.prompt([
       questions.name,
       questions.path,
@@ -52,7 +54,7 @@ async function startTemplateGenerator(template) {
     const results = {
       ...config,
       ...requiredAnswers,
-      templatesPath,
+      templatesPath: template,
     }
 
     generateFilesFromTemplate(results)

--- a/src/utils.js
+++ b/src/utils.js
@@ -121,7 +121,7 @@ async function getTemplate(templatesList, templateName = null) {
     return template
   }
   if (templateName in templatesList) {
-    return templateName
+    return templatesList[templateName]
   }
   throw Error(`The template '${templateName}' does't exists`)
 }


### PR DESCRIPTION
depends on and includes #41 

according to docs a template can by used by using the -t option.
the script tries to read out a `template` argument.

So I adjusted the code to use both, either `--template=classic` or `-t classic`

also a bit of refactoring to startTemplateGenerator with a given template...
and getTemplate was returning the name if given a template, and a path if you chose one through the CLI