### PR TITLE
classic and stateful ES7 components

### DIFF
--- a/templates/classicES7/COMPONENT_NAME.js
+++ b/templates/classicES7/COMPONENT_NAME.js
@@ -1,0 +1,13 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+class COMPONENT_NAME extends Component {
+  static defaultProps = {}
+  static propTypes = {}
+
+  render() {
+    return <div className="COMPONENT_NAME" />
+  }
+}
+
+export default COMPONENT_NAME

--- a/templates/statefulES7/COMPONENT_NAME.js
+++ b/templates/statefulES7/COMPONENT_NAME.js
@@ -1,0 +1,14 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+class COMPONENT_NAME extends Component {
+  static defaultProps = {}
+  static propTypes = {}
+  state = {}
+
+  render() {
+    return <div className="COMPONENT_NAME" />
+  }
+}
+
+export default COMPONENT_NAME


### PR DESCRIPTION
Adds 2 basic templates of React.Component with ES7 property initializers
 - Without the state object (codename: classic)
 - With an empty state object (codename: stateful)