### PR TITLE
Proposal: Expand the classic + presentational examples a little

### DIFF
--- a/templates/classic/COMPONENT_NAME.js
+++ b/templates/classic/COMPONENT_NAME.js
@@ -7,7 +7,11 @@ class COMPONENT_NAME extends Component {
   }
 
   render() {
-    return <div className="COMPONENT_NAME" />
+    return (
+      <div className="COMPONENT_NAME">
+        COMPONENT_NAME
+      </div>
+    )
   }
 }
 

--- a/templates/classicES7/COMPONENT_NAME.js
+++ b/templates/classicES7/COMPONENT_NAME.js
@@ -6,7 +6,11 @@ class COMPONENT_NAME extends Component {
   static propTypes = {}
 
   render() {
-    return <div className="COMPONENT_NAME" />
+    return (
+      <div className="COMPONENT_NAME">
+        COMPONENT_NAME
+      </div>
+    )
   }
 }
 

--- a/templates/presentational/COMPONENT_NAME.js
+++ b/templates/presentational/COMPONENT_NAME.js
@@ -2,7 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const COMPONENT_NAME = () => (
-  <div className="COMPONENT_NAME" />
+  <div className="COMPONENT_NAME">
+    COMPONENT_NAME
+  </div>
 );
 
 COMPONENT_NAME.propTypes = {}

--- a/templates/statefulES7/COMPONENT_NAME.js
+++ b/templates/statefulES7/COMPONENT_NAME.js
@@ -7,7 +7,11 @@ class COMPONENT_NAME extends Component {
   state = {}
 
   render() {
-    return <div className="COMPONENT_NAME" />
+    return (
+      <div className="COMPONENT_NAME">
+        COMPONENT_NAME
+      </div>
+    )
   }
 }
 


### PR DESCRIPTION
I think it might be a bit better if we swap
```
return <div className='COMPONENT_NAME' />
```
to
```
return (
  <div className='COMPONENT_NAME>
    COMPONENT_NAME
  </div>
)
```
in the `classic` and `presentational` examples. 

Most people will probably have their returns more complex than a single div so this should save some extra seconds.