### PR TITLE
Improved loading of configuration files

### DIFF
--- a/.ccarc.example
+++ b/.ccarc.example
@@ -1,0 +1,17 @@
+{   
+  "templatesDirPath": "./templates",
+  "path": "./src/components",
+  "jsExtension": "js",
+  "cssExtension": "css",
+  "includeTests": true,
+  "includeStories": true,
+  "indexFile": false,
+  "connected": false,
+  "componentMethods": [],
+  "fileNames": {
+    "testFileMatch": "spec",
+    "testFileName": "myTest",
+    "componentFileName": "template",
+    "styleFileName": "style"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -81,71 +81,32 @@ and searching up the file tree until a config file is (or isn't) found.
 
 ### Basic Configuration
 
-JSON:
+An example configuration file can be found here: [.ccarc.example](.ccarc.example), you can use this
+file by copying it to the root of your project.
 
-```json
-// .ccarc
-{
-  "type": "class",
-  "path": "./src/components"
-}
-```
+Currently supported options are:
 
-YAML:
-
-```yaml
-# .ccarc
-type: class
-path: ./src/components
-```
+  Option | Description
+  --- | ---
+  `type` | Default type of the component `["stateless", "class", "pure"]`
+  `templatesDirPath` | Default path to get the templates from the custom templates folder
+  `path` | Default path to create component file and folder
+  `jsExtension` | Default extension for your javascript file `["js", "jsx"]`
+  `cssExtension` | Default extension for your css file `["css", "scss", "sass", "less", false]`. Set to false if you don't want a style file
+  `includeTests` | Default flag to include a test file in the folder `[true, false]`
+  `includeStories` | Default flag to include a storybook file in the folder `[true, false]`
+  `indexFile` |  Default flag to create an index file in the folder `[false, true]`
+  `connected` | Default flag to integrate connect redux in the index file `[false, true]`
+  `componentMethods` | Only for "class" and "pure", insert method inside the component (i.e. `["componentDidMount", "shouldComponentUpdate", "onClick"]`)
+  `fileNames` | Choose the specific filename for your component's file.
+  `fileNames.testFileMatch` | specify the match part of test file
+  `fileNames.testFileName` | specify the file name of your test file
+  `fileNames.componentFileName` |  specify the component file name
+  `fileNames.styleFileName` | specify the style file name !!IMPORTANT: Include cssExtension.
 
 ### You can also pass a config file
 
 1) Create a JSON file `config.json`:  
-
-```javascript
-{   
-    // Default type of component ["stateless", "class", "pure"]
-    "type": "stateless",
-
-    // Default path to get the templates from the custom templates folder
-    "templatesDirPath": "./templates",
-
-    // Default path to create component file and folder
-    "path": "./src/components",
-
-    // Default extension for your javascript file ["js", "jsx"]
-    "jsExtension": "js",
-
-    // Default extension for your css file ["css", "scss", "sass", "less", false]
-    // Set to false if you don't want a style file
-    "cssExtension": "css",
-
-    // Default flag to include a test file in the folder [true, false]
-    "includeTests": true,
-
-    // Default flag to include a storybook file in the folder [true, false]
-    "includeStories": true,
-
-    // Default flag to create an index file in the folder [false, true]
-    "indexFile": false,
-
-    // Default flag to integrate connect redux in the index file [false, true]
-    "connected": false,
-
-    // Only for "class" and "pure", insert method inside the component
-    "componentMethods": ["componentDidMount", "shouldComponentUpdate", "onClick"],
-
-    // Choose the specific filename for your component's file.
-    "fileNames": {
-        "testFileMatch": "spec", // specify the match part of test file
-        "testFileName": "myTest", // specify the file name of your test file
-        "componentFileName": "template", // specify the component file name
-        "styleFileName": "style" // specify the style file name !!IMPORTANT: Include cssExtension.
-    }
-}
-```
-
 2) and pass the path to config param
 
 ```sh

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,20 +1,18 @@
+/* eslint-disable no-console */
 import chalk from 'chalk'
 
 const Logger = {
-  log(msg) {
-    /* eslint-disable no-console */
-    return console.log(chalk.green(JSON.stringify(msg)))
-    /* eslint-enable no-console */
+  log(...msg) {
+    return console.log(chalk.green('[Info]'), ...msg)
   },
-  error(msg) {
-    /* eslint-disable no-console */
-    return console.error(chalk.bold.red(JSON.stringify(msg)))
-    /* eslint-enable no-console */
+  error(...msg) {
+    return console.error(chalk.bold.red('[Error]'), ...msg)
   },
-  warn(msg) {
-    /* eslint-disable no-console */
-    return console.warn(chalk.keyword('orange')(JSON.stringify(msg)))
-    /* eslint-enable no-console */
+  warn(...msg) {
+    return console.warn(chalk.keyword('orange')('[Warn]'), ...msg)
+  },
+  debug(...msg) {
+    return console.warn(chalk.blue('[Debug]'), ...msg)
   },
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -124,10 +124,17 @@ function getConfig(configPath, searchPath = process.cwd(), stopDir = homedir()) 
     const configPathAbsolute = useCustomPath && path.join(process.cwd(), configPath)
     // search from the root of the process if the user didnt specify a config file,
     // or use the custom path if a file is passed.
-    const { config, filepath } = explorer.load(searchPathAbsolute, configPathAbsolute)
-    return { ...(config || {}), filepath }
+    const result = explorer.load(searchPathAbsolute, configPathAbsolute)
+
+    // dont throw if the explorer didnt find a configfile,
+    // instead use default config
+    const config = result ? result.config : {}
+    const filepath = result ? result.filepath : {}
+    if (!result) Logger.log('No config file detected, using defaults.')
+
+    return { ...config, filepath }
   } catch (error) {
-    Logger.error('Bad config file, Please check config file syntax')
+    Logger.error('An error occured while parsing your config file. Using defaults...\n\n', error.message)
   }
   return {}
 }


### PR DESCRIPTION
Previously we threw an error if we couldn't find a configuration file.
I changed this, so we would only throw if the parsing of the configuration file failed.

This fixes parts of this issue (https://github.com/CVarisco/create-component-app/issues/55).

If the user runs `create-component-app` without a configuration file, it will no longer report
` "Bad config file, Please check config file syntax."`, but a message informing the user that
we couldn't find a configuration file and continue with defaults.

I also moved the example config, which we inlined into the readme, to an example config file,
and the comments explaining the different options to a markdown table.