### PR TITLE
Add capability to use in filenames options COMPONENT_NAME replacement

### DIFF
--- a/.ccarc.example
+++ b/.ccarc.example
@@ -9,7 +9,6 @@
   "connected": false,
   "componentMethods": [],
   "fileNames": {
-    "testFileMatch": "spec",
     "testFileName": "myTest",
     "componentFileName": "template",
     "styleFileName": "style"

--- a/README.md
+++ b/README.md
@@ -98,8 +98,7 @@ Currently supported options are:
   `indexFile` |  Default flag to create an index file in the folder `[false, true]`
   `connected` | Default flag to integrate connect redux in the index file `[false, true]`
   `componentMethods` | Only for "class" and "pure", insert method inside the component (i.e. `["componentDidMount", "shouldComponentUpdate", "onClick"]`)
-  `fileNames` | Choose the specific filename for your component's file.
-  `fileNames.testFileMatch` | specify the match part of test file
+  `fileNames` | Choose the specific filename for your component's file. (COMPONENT_NAME will be replaced)
   `fileNames.testFileName` | specify the file name of your test file
   `fileNames.componentFileName` |  specify the component file name
   `fileNames.styleFileName` | specify the style file name !!IMPORTANT: Include cssExtension.

--- a/src/files.js
+++ b/src/files.js
@@ -87,13 +87,21 @@ async function generateFilesFromTemplate({ name, path, templatesPath }) {
  */
 function getFileNames(fileNames, componentName) {
   const defaultFileNames = {
-    testFileName: defaultOptions.testFileName,
-    testFileMatch: componentName,
+    testFileName: `${defaultOptions.testFileName}.${componentName}`,
     componentFileName: componentName,
     styleFileName: componentName,
   }
 
-  return { ...defaultFileNames, ...fileNames }
+  const formattedFileNames = Object.keys(fileNames).reduce(
+    (acc, curr) => {
+      acc[curr] = fileNames[curr].replace(/COMPONENT_NAME/g, componentName)
+
+      return acc
+    },
+    { ...defaultFileNames }
+  )
+
+  return formattedFileNames
 }
 
 /**
@@ -128,32 +136,18 @@ function generateFiles(params) {
   } = params
   const destination = `${path}/${name}`
 
-  const {
-    testFileName,
-    testFileMatch,
-    componentFileName,
-    styleFileName,
-  } = getFileNames(fileNames, name)
+  const { testFileName, componentFileName, styleFileName } = getFileNames(fileNames, name)
 
   if (indexFile || connected) {
-    fs.outputFile(
-      `${destination}/index.js`,
-      generateIndexFile(componentFileName, connected)
-    )
+    fs.outputFile(`${destination}/index.js`, generateIndexFile(componentFileName, connected))
   }
 
   if (includeStories) {
-    fs.outputFile(
-      `${destination}/${name}.stories.${jsExtension}`,
-      generateStorybookTemplate(name)
-    )
+    fs.outputFile(`${destination}/${name}.stories.${jsExtension}`, generateStorybookTemplate(name))
   }
 
   if (includeTests) {
-    fs.outputFile(
-      `${destination}/${testFileName}.${testFileMatch}.${jsExtension}`,
-      generateTestTemplate(name)
-    )
+    fs.outputFile(`${destination}/${testFileName}.${jsExtension}`, generateTestTemplate(name))
   }
 
   // Create js file
@@ -177,9 +171,4 @@ function generateFiles(params) {
 
 const generateFilesFromCustom = generateFilesFromTemplate
 
-export {
-  generateFiles,
-  generateFilesFromTemplate,
-  generateFilesFromCustom,
-  getDirectories,
-}
+export { generateFiles, generateFilesFromTemplate, generateFilesFromCustom, getDirectories }

--- a/src/files.js
+++ b/src/files.js
@@ -43,11 +43,10 @@ function readFile(path, fileName) {
 
 /**
  * generate the file name
- * @param {string} newFilePath
  * @param {string} newFileName
  * @param {string} templateFileName
  */
-function generateFileName(newFilePath, newFileName, templateFileName) {
+function generateFileName(newFileName, templateFileName) {
   if (templateFileName.includes('COMPONENT_NAME')) {
     return templateFileName.replace(/COMPONENT_NAME/g, newFileName)
   }
@@ -71,7 +70,7 @@ async function generateFilesFromTemplate({ name, path, templatesPath }) {
       const content = await readFile(templatesPath, templateFileName)
       const replaced = content.replace(/COMPONENT_NAME/g, name)
       // Exist ?
-      const newFileName = generateFileName(`${outputPath}/`, name, templateFileName)
+      const newFileName = generateFileName(name, templateFileName)
       // Write the new file with the new content
       fs.outputFile(`${outputPath}/${newFileName}`, replaced)
     })
@@ -102,6 +101,7 @@ function getFileNames(fileNames, componentName) {
  *
  * @param {object} params object with:
  * @param {string} type: the type of component template
+ * @param {object} fileNames: object that contains the filenames to replace
  * @param {string} name: the name of the component used to create folder and file
  * @param {string} path: where the component folder is created
  * @param {string} cssExtension: the extension of the css file
@@ -128,17 +128,25 @@ function generateFiles(params) {
   } = params
   const destination = `${path}/${name}`
 
-  const { testFileName, testFileMatch, componentFileName, styleFileName } = getFileNames(
-    fileNames,
-    name
-  )
+  const {
+    testFileName,
+    testFileMatch,
+    componentFileName,
+    styleFileName,
+  } = getFileNames(fileNames, name)
 
   if (indexFile || connected) {
-    fs.outputFile(`${destination}/index.js`, generateIndexFile(componentFileName, connected))
+    fs.outputFile(
+      `${destination}/index.js`,
+      generateIndexFile(componentFileName, connected)
+    )
   }
 
   if (includeStories) {
-    fs.outputFile(`${destination}/${name}.stories.${jsExtension}`, generateStorybookTemplate(name))
+    fs.outputFile(
+      `${destination}/${name}.stories.${jsExtension}`,
+      generateStorybookTemplate(name)
+    )
   }
 
   if (includeTests) {
@@ -168,4 +176,9 @@ function generateFiles(params) {
 }
 
 const generateFilesFromCustom = generateFilesFromTemplate
-export { generateFiles, generateFilesFromTemplate, generateFilesFromCustom, getDirectories }
+export {
+  generateFiles,
+  generateFilesFromTemplate,
+  generateFilesFromCustom,
+  getDirectories,
+}

--- a/src/files.js
+++ b/src/files.js
@@ -176,6 +176,7 @@ function generateFiles(params) {
 }
 
 const generateFilesFromCustom = generateFilesFromTemplate
+
 export {
   generateFiles,
   generateFilesFromTemplate,


### PR DESCRIPTION
As a user, I want to use the filenames options to change the filenames of my template using also the `COMPONENT_NAME` replacement.

Also, referred to #57 this PR will include the capability to choose the format that the user wants.