### PR TITLE
Fix generateComponentMethods that print null when is empty

### DIFF
--- a/src/defaultTemplates/js/common.template.js
+++ b/src/defaultTemplates/js/common.template.js
@@ -6,18 +6,26 @@ const COMPONENT_TYPES = {
 }
 
 function generateReactImport(componentType) {
-  return `import React${componentType !== 'stateless' ? `, { ${COMPONENT_TYPES[componentType]} }` : ''} from 'react'`
+  return `import React${
+    componentType !== 'stateless' ? `, { ${COMPONENT_TYPES[componentType]} }` : ''
+  } from 'react'`
 }
 
+/**
+ * Create the concatenation of methods string that will be injected into class and pure components
+ * @param {Array} componentMethods
+ * @return {String} methods
+ */
 function generateComponentMethods(componentMethods) {
   if (componentMethods.length === 0) {
-    return null
+    return ''
   }
-  let methods = ''
-  componentMethods.forEach((method) => {
-    methods += `\n\xa0\xa0\xa0\xa0${method}(){}\n`
-  })
-  return methods
+
+  return componentMethods.reduce((acc, method) => {
+    const methods = `${acc}\n\xa0\xa0\xa0\xa0${method}(){}\n`
+
+    return methods
+  }, '')
 }
 
 function generateImports(


### PR DESCRIPTION
When the option 'componentMethods' is empty, should return `''` and not `null`.
Referred to #68 

Thanks a lot to @vemv 👍 