### PR TITLE
enable alternate replacement keys to control case of replaced strings

### DIFF
--- a/docs/CUSTOM-TEMPLATES.md
+++ b/docs/CUSTOM-TEMPLATES.md
@@ -2,6 +2,17 @@
 
 With this library you can create your own templates and use them to generate your components in a second!
 
+`create-component-app` offers 4 replacement keys which can be used in the names of the files in your template, as well as within the templates themselves.  Each key corresponds to a formatted transformation of the component name that you enter when running `create-component-app`.
+
+#### Keys and Replacements
+  Replacement Key | Description
+  --- | ---
+  `COMPONENT_NAME` | Each instance of the string is replaced with the component name that you entered without modification.  This is the standard behavior.  (eg: `MyComponent` => `MyComponent` and replaces all instances of `COMPONENT_NAME` in files and file names.)
+  `COMPONENT_CAP_NAME` | Each instance of the string is replaced with an uppercased transformation of the component name that you entered. (eg: `MyComponent` => `MYCOMPONENTNAME` and replaces all instances of `COMPONENT_CAP_NAME` in files and file names.)
+  `component_name` | Each instance of the string is replaced with a lowercased transformation of the component name that you entered. (eg: `MyComponent` => `mycomponentname` and replaces all instances of `component_name` in files and file names.)
+  `cOMPONENT_NAME` | Each instance of the string is replaced with a lower camel case transformation of the component name that you entered. For clarity, the first letter is simply lowercased.  (eg: `MyComponent` => `myComponent` and replaces all instances of `cOMPONENT_NAME` in files and file names.)
+
+
 ### 1) Create your custom template folder
 
 Create a folder to contain all your custom templates.

--- a/src/files.js
+++ b/src/files.js
@@ -43,15 +43,15 @@ function readFile(path, fileName) {
 
 /**
  * generate the file name
- * @param {string} newFileName
- * @param {string} templateFileName
+ * @param {string} searchString
+ * @param {string} replacement
  */
-function generateFileName(newFileName, templateFileName) {
+function replaceKeys(searchString, replacement) {
   const replacementKeys = {
-    COMPONENT_NAME: newFileName,
-    component_name: newFileName.toLowerCase(),
-    COMPONENT_CAP_NAME: newFileName.toUpperCase(),
-    cOMPONENT_NAME: newFileName[0].toLowerCase() + newFileName.substr(1),
+    COMPONENT_NAME: replacement,
+    component_name: replacement.toLowerCase(),
+    COMPONENT_CAP_NAME: replacement.toUpperCase(),
+    cOMPONENT_NAME: replacement[0].toLowerCase() + replacement.substr(1),
   }
 
   return Object.keys(replacementKeys).reduce(
@@ -62,7 +62,7 @@ function generateFileName(newFileName, templateFileName) {
       }
       return acc
     },
-    templateFileName
+    searchString
   )
 }
 
@@ -81,12 +81,10 @@ async function generateFilesFromTemplate({ name, path, templatesPath }) {
     files.map(async (templateFileName) => {
       // Get the template content
       const content = await readFile(templatesPath, templateFileName)
-      const replaced = content.replace(/COMPONENT_NAME/g, name)
-                         .replace(/component_name/g, name.toLowerCase())
-                         .replace(/COMPONENT_CAP_NAME/g, name.toUpperCase())
-                         .replace(/cOMPONENT_NAME/g, name[0].toLowerCase() + name.substr(1))
+      const replaced = replaceKeys(content, name)
+
       // Exist ?
-      const newFileName = generateFileName(name, templateFileName)
+      const newFileName = replaceKeys(templateFileName, name)
       // Write the new file with the new content
       fs.outputFile(`${outputPath}/${newFileName}`, replaced)
     })
@@ -110,10 +108,7 @@ function getFileNames(fileNames = [], componentName) {
 
   const formattedFileNames = Object.keys(fileNames).reduce(
     (acc, curr) => {
-      acc[curr] = fileNames[curr].replace(/COMPONENT_NAME/g, componentName)
-                    .replace(/component_name/g, componentName.toLowerCase())
-                    .replace(/COMPONENT_CAP_NAME/g, componentName.toUpperCase())
-                    .replace(/cOMPONENT_NAME/g, componentName[0].toUpperCase() + componentName.substr(1))
+      acc[curr] = replaceKeys(fileNames[curr], componentName)
       return acc
     },
     { ...defaultFileNames }

--- a/src/files.js
+++ b/src/files.js
@@ -47,20 +47,23 @@ function readFile(path, fileName) {
  * @param {string} templateFileName
  */
 function generateFileName(newFileName, templateFileName) {
-  let generatedFileName = templateFileName
-  if (templateFileName.includes('COMPONENT_NAME')) {
-    generatedFileName = templateFileName.replace(/COMPONENT_NAME/g, newFileName)
+  const replacementKeys = {
+    COMPONENT_NAME: newFileName,
+    component_name: newFileName.toLowerCase(),
+    COMPONENT_CAP_NAME: newFileName.toUpperCase(),
+    cOMPONENT_NAME: newFileName[0].toLowerCase() + newFileName.substr(1),
   }
-  if (templateFileName.includes('component_name')) {
-    generatedFileName = templateFileName.replace(/component_name/g, newFileName.toLowerCase())
-  }
-  if (templateFileName.includes('COMPONENT_CAP_NAME')) {
-    generatedFileName = templateFileName.replace(/COMPONENT_CAP_NAME/g, newFileName.toUpperCase())
-  }
-  if (templateFileName.includes('cOMPONENT_NAME')) {
-    generatedFileName = templateFileName.replace(/cOMPONENT_NAME/g, newFileName[0].toLowerCase() + newFileName.substr(1))
-  }
-  return generatedFileName
+
+  return Object.keys(replacementKeys).reduce(
+    (acc, curr) => {
+      if (acc.includes(curr)) {
+        const regEx = new RegExp(curr, 'g')
+        return acc.replace(regEx, replacementKeys[curr])
+      }
+      return acc
+    },
+    templateFileName
+  )
 }
 
 /**

--- a/src/files.js
+++ b/src/files.js
@@ -50,6 +50,15 @@ function generateFileName(newFileName, templateFileName) {
   if (templateFileName.includes('COMPONENT_NAME')) {
     return templateFileName.replace(/COMPONENT_NAME/g, newFileName)
   }
+  if (templateFileName.includes('component_name')) {
+    return templateFileName.replace(/component_name/g, newFileName.toLowerCase())
+  }
+  if (templateFileName.includes('COMPONENT_CAP_NAME')) {
+    return templateFileName.replace(/COMPONENT_CAP_NAME/g, newFileName.toUpperCase())
+  }
+  if (templateFileName.includes('cOMPONENT_NAME')) {
+    return templateFileName.replace(/cOMPONENT_NAME/g, newFileName[0].toLowerCase() + newFileName.substr(1))
+  }
   return templateFileName
 }
 
@@ -69,6 +78,9 @@ async function generateFilesFromTemplate({ name, path, templatesPath }) {
       // Get the template content
       const content = await readFile(templatesPath, templateFileName)
       const replaced = content.replace(/COMPONENT_NAME/g, name)
+                         .replace(/component_name/g, name.toLowerCase())
+                         .replace(/COMPONENT_CAP_NAME/g, name.toUpperCase())
+                         .replace(/cOMPONENT_NAME/g, name[0].toLowerCase() + name.substr(1))
       // Exist ?
       const newFileName = generateFileName(name, templateFileName)
       // Write the new file with the new content
@@ -95,7 +107,9 @@ function getFileNames(fileNames = [], componentName) {
   const formattedFileNames = Object.keys(fileNames).reduce(
     (acc, curr) => {
       acc[curr] = fileNames[curr].replace(/COMPONENT_NAME/g, componentName)
-
+                    .replace(/component_name/g, componentName.toLowerCase())
+                    .replace(/COMPONENT_CAP_NAME/g, componentName.toUpperCase())
+                    .replace(/cOMPONENT_NAME/g, componentName[0].toUpperCase() + componentName.substr(1))
       return acc
     },
     { ...defaultFileNames }

--- a/src/files.js
+++ b/src/files.js
@@ -47,7 +47,7 @@ function readFile(path, fileName) {
  * @param {string} templateFileName
  */
 function generateFileName(newFileName, templateFileName) {
-  let generatedFileName = templateFileName;
+  let generatedFileName = templateFileName
   if (templateFileName.includes('COMPONENT_NAME')) {
     generatedFileName = templateFileName.replace(/COMPONENT_NAME/g, newFileName)
   }

--- a/src/files.js
+++ b/src/files.js
@@ -47,19 +47,20 @@ function readFile(path, fileName) {
  * @param {string} templateFileName
  */
 function generateFileName(newFileName, templateFileName) {
+  let generatedFileName = templateFileName;
   if (templateFileName.includes('COMPONENT_NAME')) {
-    return templateFileName.replace(/COMPONENT_NAME/g, newFileName)
+    generatedFileName = templateFileName.replace(/COMPONENT_NAME/g, newFileName)
   }
   if (templateFileName.includes('component_name')) {
-    return templateFileName.replace(/component_name/g, newFileName.toLowerCase())
+    generatedFileName = templateFileName.replace(/component_name/g, newFileName.toLowerCase())
   }
   if (templateFileName.includes('COMPONENT_CAP_NAME')) {
-    return templateFileName.replace(/COMPONENT_CAP_NAME/g, newFileName.toUpperCase())
+    generatedFileName = templateFileName.replace(/COMPONENT_CAP_NAME/g, newFileName.toUpperCase())
   }
   if (templateFileName.includes('cOMPONENT_NAME')) {
-    return templateFileName.replace(/cOMPONENT_NAME/g, newFileName[0].toLowerCase() + newFileName.substr(1))
+    generatedFileName = templateFileName.replace(/cOMPONENT_NAME/g, newFileName[0].toLowerCase() + newFileName.substr(1))
   }
-  return templateFileName
+  return generatedFileName
 }
 
 /**


### PR DESCRIPTION
@CVarisco this branch  addresses my request made in issue #73.  I know you closed the issue saying it wasn't something you wanted to do, and I respect that.  But I still needed this functionality so I built it.

You expressed a desire to leave the existing API unchanged, this commit achieves that.  It ONLY adds new functionality and is completely backwards compatible.  Added functionality is as follows: 

--
Templates can now contain 3 additional replacement keys (if desired)
* `component_name`: applies a .toLowerCase() to the specified component name and uses that for replacement
* `COMPONENT_CAP_NAME`: applies a .toUpperCase() to the specified component name and uses that for replacement
* `cOMPONENT_NAME`: applies a .toLowerCase() to the first character of the specified component name and uses that for replacement
--

Just like the existing COMPONENT_NAME replacement, these new keys can be applied to files or to content within a file.

I was unaware of a test suite to write tests for, so there's no update to automated tests.  I'd be happy to add tests if you show me how/where to do that.
